### PR TITLE
feat: implement logic, tests and documentation for LIC10 (fixes #12)

### DIFF
--- a/src/main/java/se/kth/dd2480/group15/model/LicEvaluator.java
+++ b/src/main/java/se/kth/dd2480/group15/model/LicEvaluator.java
@@ -115,8 +115,44 @@ public class LicEvaluator {
         return false;
     }
 
-    public boolean Lic10() {
-        // TODO Implement functionality
+    /**
+     * Checks if there exists at least 1 set of 3 data points: separated by exactly e_pts and f_pts
+     * consecutive intervening points, respectively, that can create a triangle area greater than area1. 
+     * (Condition is not met when numpoints < 5).
+     * @param numpoints the number of points in the array (must be at least 5)
+     * @param points an array of Point objects representing the coordinates of points 
+     * @param params a Parameters object containing the e_pts, f_pts and area1 value for the evaluation
+     * @return true if at least one triangle, where the condition is met, is found. False otherwise.
+     */
+    public boolean Lic10(int numpoints, Point[] pt, Parameters params) {
+        int e_pts = params.ePts();
+        int f_pts = params.fPts();
+        double area1 = params.area1();
+
+        // verify input
+        if (!(e_pts >= 1 && f_pts >= 1 && (e_pts + f_pts) <= (numpoints - 3) && numpoints >= 5))
+            return false;
+
+        /**
+         * We want e_pts between p1 och p2 
+         * And at the same time f_pts between p2 and p3 
+         */
+        for(int i = 0; i < numpoints - (e_pts + f_pts + 2); i++){
+            Point p1 = pt[i];
+            Point p2 = pt[i + e_pts + 1];
+            Point p3 = pt[i + e_pts + f_pts + 2];
+
+            // get positive area of a triangle from 3 coordinates
+            double area = (0.5)*Math.abs(
+                (p1.x() * (p2.y()- p3.y())) + 
+                (p2.x() * (p3.y()- p1.y())) + 
+                (p3.x() * (p1.y()- p2.y())));
+
+            // if area > area1 
+            if (Utils.doubleCompare(area, area1) == CompType.GT) 
+                return true;
+            }
+
         return false;
     }
 
@@ -177,7 +213,7 @@ public class LicEvaluator {
         results[7] = Lic7();
         results[8] = Lic8();
         results[9] = Lic9();
-        results[10] = Lic10();
+        results[10] = Lic10(numpoints, pt, params);
         results[11] = Lic11(numpoints, pt, params.gPts());
         results[12] = Lic12();
         results[13] = Lic13();

--- a/src/test/java/se/kth/dd2480/group15/model/LicEvaluatorTest.java
+++ b/src/test/java/se/kth/dd2480/group15/model/LicEvaluatorTest.java
@@ -170,8 +170,122 @@ class LicEvaluatorTest {
     void lic9() {
     }
 
+    /**
+     * Positive test case
+     * 3 points separated correctly with minimum Point array size
+     * Expecting the function to return true
+     */
     @Test
-    void lic10() {
+    void lic10_threePointsSeparatedCorrectly_minimumDataPoints_returnsTrue() {
+        Parameters params = Parameters.builder().ePts(1).fPts(1).area1(1.0).build();
+        Point[] points = {
+            new Point(0,0), // p1
+            new Point(0,0),
+            new Point(2,0), // p2
+            new Point(0,0),
+            new Point(0,2), // p3
+        };
+        LicEvaluator evaluator = new LicEvaluator();
+        assertTrue(evaluator.Lic10(points.length, points, params));
+    }
+
+    /**
+     * Positive test case 
+     * 3 points separated correctly
+     * Expecting the function to return true
+     */
+    @Test
+    void lic10_threePointsSeparatedCorrectly_returnsTrue() {
+        Parameters params = Parameters.builder().ePts(1).fPts(2).area1(1.0).build();
+        Point[] points = {
+            new Point(0,0), // p1
+            new Point(0,0),
+            new Point(2,0), // p2
+            new Point(0,0),
+            new Point(0,0),
+            new Point(0,2), // p3
+        };
+        LicEvaluator evaluator = new LicEvaluator();
+        assertTrue(evaluator.Lic10(points.length, points, params));
+    }
+
+    /**
+     * Positive test case 
+     * 3 points separated correctly later in the points array
+     * Expecting the function to return true
+     */
+    @Test
+    void lic10_validTriangleLaterInArray_returnsTrue() {
+        Parameters params = Parameters.builder().ePts(1).fPts(1).area1(1.0).build();
+        Point[] points = {
+            new Point(0,0), // ignore
+            new Point(0,0), // ignore
+            new Point(0,0), // p1
+            new Point(0,0),
+            new Point(2,0), // p2
+            new Point(0,0),
+            new Point(0,2), // p3
+        };
+        LicEvaluator evaluator = new LicEvaluator();
+        assertTrue(evaluator.Lic10(points.length, points, params));
+    }
+
+    /**
+     * Negative test case 
+     * 3 points exists but separated incorrectly
+     * Expecting the function to return false
+     */
+    @Test 
+    void lic10_threePointsSeparatedIncorrectly_returnsFalse() {
+        Parameters params = Parameters.builder().ePts(1).fPts(2).area1(1.0).build();
+        Point[] points = {
+            new Point(0,0), // p1
+            new Point(0,0),
+            new Point(2,0), // p2
+            new Point(0,0),
+            new Point(0,0),
+            new Point(1,0), // p3
+            new Point(0,2), 
+        };
+        LicEvaluator evaluator = new LicEvaluator();
+        assertFalse(evaluator.Lic10(points.length, points, params));
+    }
+
+    /**
+     * Negative test case 
+     * ePts set to zero
+     * Expecting the function to return false
+     */
+    @Test 
+    void lic10_eptsOutOfRange_returnsFalse() {
+        Parameters params = Parameters.builder().ePts(0).fPts(2).area1(1.0).build();
+        Point[] points = {
+            new Point(0,0), // p1
+            new Point(2,0), // p2
+            new Point(0,0),
+            new Point(0,0),
+            new Point(0,0), // p3
+        };
+        LicEvaluator evaluator = new LicEvaluator();
+        assertFalse(evaluator.Lic10(points.length, points, params));
+    }
+
+    /**
+     * Negative test case 
+     * points array is too small
+     * Expecting the function to return false
+     */
+    @Test 
+    void lic10_pointsArraySizeTooSmall_returnsFalse() {
+        Parameters params = Parameters.builder().ePts(1).fPts(1).area1(1.0).build();
+        Point[] points = {
+            new Point(0,0), // p1
+            new Point(2,0), 
+            new Point(0,0), // p2
+            new Point(0,2),
+        };
+        LicEvaluator evaluator = new LicEvaluator();
+        assertFalse(evaluator.Lic10(points.length, points, params));
     }
 
     //LIC11


### PR DESCRIPTION
* Implements logic for LIC10 using same triangle area formula as LIC3 (might want to make a function in utils later).
* Follows requirements of: E_PTS and F_PTS points between p1, p2, p3.
* Adds 6 unit tests covering 3 positive and 3 negative tests.
* Adds correct documentation for the lic10 function and all test cases.