### PR TITLE
fix: fix calculation of getCircleRadius + tests, fixes #48

### DIFF
--- a/src/main/java/se/kth/dd2480/group15/utils/Utils.java
+++ b/src/main/java/se/kth/dd2480/group15/utils/Utils.java
@@ -1,6 +1,7 @@
 package se.kth.dd2480.group15.utils;
 
 import se.kth.dd2480.group15.model.Point;
+import java.util.Arrays;
 
 /**
  * Collection of static utility methods used when checking LICs truth values.
@@ -57,7 +58,44 @@ public class Utils {
     }
 
     /**
-     * Computes the radius of the circle passing through all three given points.
+     * Computes the radius of the smallest circle that contains all three points.
+     * 
+     * @param p1 The first point.
+     * @param p2 The second point.
+     * @param p3 The third point.
+     * @return the radius of the smallest circle that contains all three points.
+     */
+    public static double getCircleRadius(Point p1, Point p2, Point p3) {
+        // Get all coordinates
+        double x1 = p1.x(), y1 = p1.y();
+        double x2 = p2.x(), y2 = p2.y();
+        double x3 = p3.x(), y3 = p3.y();
+
+        // Get side lengths
+        double d12 = Math.hypot(x1-x2, y1-y2);
+        double d13 = Math.hypot(x1-x3, y1-y3);
+        double d23 = Math.hypot(x2-x3, y2-y3);
+
+        // Get longest, middle and shortest side length
+        double[] values = {d12, d13, d23};
+        Arrays.sort(values);
+        double longest = values[2], mid = values[1], shortest = values[0];
+
+        double radius;
+        if (longest*longest >= mid*mid + shortest*shortest) {
+            // The three points make a right or obtuse triangle
+            radius = longest / 2;
+        }
+        else {
+            // The three points make an acute triangle
+            radius = getRadiusFrom3(p1, p2, p3);
+        }
+
+        return radius;
+    }
+
+    /**
+     *  Calculates the radius of the circle passing through all three given points.
      * 
      * @param p1 The first point.
      * @param p2 The second point.
@@ -65,7 +103,7 @@ public class Utils {
      * @return the radius of the circle constructed by the three points or -1 if 
      * no such circle can be constructed.
      */
-    public static double getCircleRadius(Point p1, Point p2, Point p3) {
+    private static double getRadiusFrom3(Point p1, Point p2, Point p3) {
         // Get all coordinates
         double x1 = p1.x(), y1 = p1.y();
         double x2 = p2.x(), y2 = p2.y();

--- a/src/test/java/se/kth/dd2480/group15/utils/UtilsTest.java
+++ b/src/test/java/se/kth/dd2480/group15/utils/UtilsTest.java
@@ -117,24 +117,25 @@ class UtilsTest {
     }
 
     /**
-     * Verifies that collinear points return -1.
+     * Verifies that collinear points return the correct radius.
      */
     @Test
     void getCircleRadius_collinearPoints() {
         Point p1 = new Point(0, 0);
-        Point p2 = new Point(1, 0);
-        Point p3 = new Point(2, 0);
+        Point p2 = new Point(2, 0);
+        Point p3 = new Point(6, 0);
 
         double radius = Utils.getCircleRadius(p1, p2, p3);
+        double expected = 3;
 
-        assertEquals(-1, radius, TEST_PRECISION);
+        assertEquals(expected, radius, TEST_PRECISION);
     }
 
     /**
-     * Verifies that the correct radius is calculated for a simple example
+     * Verifies that the correct radius is calculated for a set of points that make a right triangle.
      */
     @Test 
-    void getCircleRadius_simpleExample() {
+    void getCircleRadius_rightTriangle() {
         Point p1 = new Point(0, 0);
         Point p2 = new Point(4, 0);
         Point p3 = new Point(0, 3);
@@ -146,16 +147,61 @@ class UtilsTest {
     }
 
     /**
-     * Verifies that the correct radius is calculated for a set of points with non-vertical and non-horizontal lines
+     * Verifies that the correct radius is calculated for a set of points that make an acute triangle.
      */
     @Test
-    void getCircleRadius_nonVerticalnonHorizontal() {
-        Point p1 = new Point(1,2);
-        Point p2 = new Point(4,5);
-        Point p3 = new Point(6,3);
+    void getCircleRadius_acuteTriangle() {
+        Point p1 = new Point(0,4);
+        Point p2 = new Point(-2,0);
+        Point p3 = new Point(2,0);
 
         double radius = Utils.getCircleRadius(p1, p2, p3);
-        double expected = Math.sqrt((1-3.5)*(1-3.5) + (2-2.5)*(2-2.5));
+        double expected = 2.5;
+
+        assertEquals(expected, radius, TEST_PRECISION);
+    }
+
+    /**
+     * Verifies that the correct radius is calculated for a set of points that make an obtuse triangle.
+     */
+    @Test
+    void getCircleRadius_obtuseTriangle() {
+        Point p1 = new Point(1,4);
+        Point p2 = new Point(2,4);
+        Point p3 = new Point(3,3);
+
+        double radius = Utils.getCircleRadius(p1, p2, p3);
+        double expected = Math.sqrt((3-1)*(3-1) + (3-4)*(3-4)) / 2;
+
+        assertEquals(expected, radius, TEST_PRECISION);
+    }
+
+    /**
+     * Verifies that the correct radius is calculated if all three points coincide.
+     */
+    @Test
+    void getCircleRadius_threePointsCoincide() {
+        Point p1 = new Point(1,4);
+        Point p2 = new Point(1,4);
+        Point p3 = new Point(1,4);
+
+        double radius = Utils.getCircleRadius(p1, p2, p3);
+        double expected = 0;
+
+        assertEquals(expected, radius, TEST_PRECISION);
+    }
+
+     /**
+     * Verifies that the correct radius is calculated if two points coincide.
+     */
+    @Test
+    void getCircleRadius_twoPointsCoincide() {
+        Point p1 = new Point(1,4);
+        Point p2 = new Point(1,4);
+        Point p3 = new Point(5,2);
+
+        double radius = Utils.getCircleRadius(p1, p2, p3);
+        double expected = Math.sqrt((5-1)*(5-1) + (2-4)*(2-4)) / 2;
 
         assertEquals(expected, radius, TEST_PRECISION);
     }


### PR DESCRIPTION
1. Fix the calculation to differentiate between acute triangles and right or obtuse triangles.
2. Fix + add some tests for getCircleRadius.