### PR TITLE
fix: adding missing javadoc comment for lic5 and its corresponding tests (refs #45)

### DIFF
--- a/src/main/java/se/kth/dd2480/group15/model/LicEvaluator.java
+++ b/src/main/java/se/kth/dd2480/group15/model/LicEvaluator.java
@@ -154,16 +154,17 @@ public class LicEvaluator {
         return false;
     }
 
-    public boolean Lic5(int numPoints, Point[] points) {
-        /* 
-        Input: n (integer, number of data points), 
-               points (arrays of Point containing the x and y coordinates of the data points)
+    /**
+     * Checks if there exists at least one set of two consecutive data points, (X[i],Y[i]) and (X[j],Y[j]), such
+     * that X[j] - X[i] < 0. (where i = j-1)
+     * <p>
+     * @param numPoints the number of data points in the array
+     * @param points an array containing the (x,y) coordinates for each point.
+     * @return {@code true} if there exists at least one set of two consecutive data points such that X[j] - X[i] < 0;
+     *         {@code false} otherwise.
+     */
 
-        Output: boolean (true if the condition is met, false otherwise)       
-        
-        Functionality: There exists at least one set of two consecutive data points, (X[i],Y[i]) and (X[j],Y[j]), such
-        that X[j] - X[i] < 0. (where i = j-1)
-        */
+    public boolean Lic5(int numPoints, Point[] points) {
 
         for(int i=1; i<numPoints; i++)
             if(points[i].x() - points[i-1].x() < 0)

--- a/src/test/java/se/kth/dd2480/group15/model/LicEvaluatorTest.java
+++ b/src/test/java/se/kth/dd2480/group15/model/LicEvaluatorTest.java
@@ -291,7 +291,9 @@ class LicEvaluatorTest {
 
     /**
      * Test case where there are two consecutive points with decreasing x-coordinates.
-     * Expecting the function to return true
+     * Expecting the function to return {@code true}
+     * <p>
+     * Test setup: 3 points (1,2), (3,4), (2,5) where points (3,4) and (2,5) have decreasing x-coordinates.
      */
     @Test
     void lic5_returnsTrue() {
@@ -302,7 +304,9 @@ class LicEvaluatorTest {
 
     /**
      * Test case where there are no two consecutive points with decreasing x-coordinates
-     * Expecting the function to return false
+     * Expecting the function to return {@code false}
+     * <p>
+     * Test setup: 3 points (1,2), (2,4), (3,6) where all points have increasing x-coordinates.
      */
     @Test
     void lic5_returnsFalse() {
@@ -313,7 +317,9 @@ class LicEvaluatorTest {
 
     /**
      * Test case with only one point.
-     * Expecting the function to return false
+     * Expecting the function to return {@code false}
+     * <p>
+     * Test setup: 1 point (5,2)
      */
     @Test
     void lic5_onePoint_returnsFalse() {


### PR DESCRIPTION
Add missing javadoc comment for lic5 under LicEvaluator class and its corresponding tests under the LicEvaluatorTest class